### PR TITLE
Convert root to realpath and add to loadpath

### DIFF
--- a/lib/rory/application.rb
+++ b/lib/rory/application.rb
@@ -39,7 +39,7 @@ module Rory
       end
 
       def root=(root_path)
-        @root = Pathname.new(root_path).expand_path
+        $:.unshift @root = Pathname.new(root_path).realpath
       end
     end
 

--- a/spec/lib/rory/application_spec.rb
+++ b/spec/lib/rory/application_spec.rb
@@ -1,10 +1,32 @@
 describe Rory::Application do
   let(:subject) {
     Class.new(Rory::Application).tap { |app|
-      app.root = "whatever"
+      app.root = root
       app.turn_off_request_logging!
     }
   }
+  let(:root){"spec/fixture_app"}
+
+  describe ".root=" do
+    let(:root) { "current_app" }
+    before { `ln -s spec/fixture_app current_app` }
+    after { `rm current_app` }
+
+    it 'appends to the load path' do
+      expect($:).to receive(:unshift).with(Pathname("current_app").realpath)
+      subject
+    end
+  end
+
+  describe ".root" do
+    let(:root) { "current_app" }
+    before { `ln -s spec/fixture_app current_app` }
+    after { `rm current_app` }
+
+    it "returns the realpath" do
+      expect(subject.root.to_s).to match(/spec\/fixture_app/)
+    end
+  end
 
   describe ".configure" do
     it 'yields the given block to self' do


### PR DESCRIPTION
Where root is set in enables require("modules/user") no require_relative `required`.
The passed in root value will be converted to a realpath to avoid double loads happening when using require_relative, which also uses the realpath