### PR TITLE
Require Rory::VERSION

### DIFF
--- a/lib/rory.rb
+++ b/lib/rory.rb
@@ -9,6 +9,7 @@ require 'rory/dispatcher'
 require 'rory/route'
 require 'rory/support'
 require 'rory/controller'
+require 'rory/version'
 
 module Rory
   class << self


### PR DESCRIPTION
This is needed to detected Rory compatibility for the new initializers feature.